### PR TITLE
chore: fix inconsistent behaviour of expandable section when  you switch the selected client

### DIFF
--- a/packages/ui/src/components/KafkaInstanceDrawer/components/KafkaSampleCode.tsx
+++ b/packages/ui/src/components/KafkaInstanceDrawer/components/KafkaSampleCode.tsx
@@ -112,6 +112,7 @@ export const KafkaSampleCode: VoidFunctionComponent<KafkaSampleCodeProps> = ({
                     tokenEndpointUrl
                   )}
                   expandableCode={javaConfigExpandabledBlock}
+                  codeSnippet={clientSelect}
                 />
               );
             case "python":
@@ -121,6 +122,7 @@ export const KafkaSampleCode: VoidFunctionComponent<KafkaSampleCodeProps> = ({
                   expandableCode={pythonConfigExpandabledBlock(
                     kafkaBootstrapUrl
                   )}
+                  codeSnippet={clientSelect}
                 />
               );
             case "quarkus":
@@ -131,6 +133,7 @@ export const KafkaSampleCode: VoidFunctionComponent<KafkaSampleCodeProps> = ({
                     kafkaBootstrapUrl,
                     tokenEndpointUrl
                   )}
+                  codeSnippet={clientSelect}
                 />
               );
             case "springboot":
@@ -141,6 +144,7 @@ export const KafkaSampleCode: VoidFunctionComponent<KafkaSampleCodeProps> = ({
                     tokenEndpointUrl
                   )}
                   expandableCode={springBootConfigExpandableBlock}
+                  codeSnippet={clientSelect}
                 />
               );
             default:
@@ -158,6 +162,7 @@ export const KafkaSampleCode: VoidFunctionComponent<KafkaSampleCodeProps> = ({
             <SampleCodeSnippet
               codeBlockCode={quarkusProducerCodeBlock}
               expandableCode={quarkusProducerExpandableBlock}
+              codeSnippet={clientSelect}
             />
           </>
         ) : (
@@ -181,6 +186,7 @@ export const KafkaSampleCode: VoidFunctionComponent<KafkaSampleCodeProps> = ({
                     <SampleCodeSnippet
                       codeBlockCode={javaProducerCodeBlock}
                       expandableCode={javaProducerExpandableBlock}
+                      codeSnippet={clientSelect}
                     />
                   );
                 case "python":
@@ -190,6 +196,7 @@ export const KafkaSampleCode: VoidFunctionComponent<KafkaSampleCodeProps> = ({
                     <SampleCodeSnippet
                       codeBlockCode={springBootProducerCodeBlock}
                       expandableCode={springBootProducerExpandableBlock}
+                      codeSnippet={clientSelect}
                     />
                   );
                 default:
@@ -216,6 +223,7 @@ export const KafkaSampleCode: VoidFunctionComponent<KafkaSampleCodeProps> = ({
             <SampleCodeSnippet
               codeBlockCode={springBootConsumerConfigCodeBlock}
               expandableCode={springBootConsumerConfigExpandableBlock}
+              codeSnippet={clientSelect}
             />
             <Text component={TextVariants.h4} className="pf-u-mt-xl">
               {t("sample_code.spring_boot_listener")}
@@ -226,6 +234,7 @@ export const KafkaSampleCode: VoidFunctionComponent<KafkaSampleCodeProps> = ({
             <SampleCodeSnippet
               codeBlockCode={springBootListenerCodeBlock}
               expandableCode={springBootListenerExpandableBlock}
+              codeSnippet={clientSelect}
             />
             <Text component={TextVariants.h4} className="pf-u-mt-xl">
               {t("sample_code.spring_boot_consumer")}
@@ -236,6 +245,7 @@ export const KafkaSampleCode: VoidFunctionComponent<KafkaSampleCodeProps> = ({
             <SampleCodeSnippet
               codeBlockCode={springBootConsumerExampleCodeBlock}
               expandableCode={springBootConsumerExampleExpandableBlock}
+              codeSnippet={clientSelect}
             />
           </>
         ) : (
@@ -256,6 +266,7 @@ export const KafkaSampleCode: VoidFunctionComponent<KafkaSampleCodeProps> = ({
                     <SampleCodeSnippet
                       codeBlockCode={javaConsumerCodeBlock}
                       expandableCode={javaConsumerExpandableBlock}
+                      codeSnippet={clientSelect}
                     />
                   );
                 case "python":
@@ -263,6 +274,7 @@ export const KafkaSampleCode: VoidFunctionComponent<KafkaSampleCodeProps> = ({
                     <SampleCodeSnippet
                       codeBlockCode={pythonConsumerCodeBlock}
                       expandableCode={pythonConsumerExpandableBlock}
+                      codeSnippet={clientSelect}
                     />
                   );
                 case "quarkus":
@@ -270,6 +282,7 @@ export const KafkaSampleCode: VoidFunctionComponent<KafkaSampleCodeProps> = ({
                     <SampleCodeSnippet
                       codeBlockCode={quarkusConsumerCodeBlock}
                       expandableCode={quarkusConsumerExpandableBlock}
+                      codeSnippet={clientSelect}
                     />
                   );
                 default:

--- a/packages/ui/src/components/KafkaInstanceDrawer/components/SampleCodeSnippet.tsx
+++ b/packages/ui/src/components/KafkaInstanceDrawer/components/SampleCodeSnippet.tsx
@@ -6,20 +6,27 @@ import {
   ExpandableSection,
   ExpandableSectionToggle,
 } from "@patternfly/react-core";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { VoidFunctionComponent } from "react";
+
+export type ClientType = "java" | "python" | "quarkus" | "springboot";
 
 export type SampleCodeSnippetProps = {
   expandableCode?: string;
   codeBlockCode: string;
+  codeSnippet?: ClientType;
 };
 
 export const SampleCodeSnippet: VoidFunctionComponent<
   SampleCodeSnippetProps
-> = ({ expandableCode, codeBlockCode }) => {
+> = ({ expandableCode, codeBlockCode, codeSnippet }) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
   const [copied, setCopied] = useState<boolean>(false);
+
+  useEffect(() => {
+    setIsExpanded(false);
+  }, [codeSnippet]);
 
   const clipboardCopyFunc = (_event: any, text: string) => {
     navigator.clipboard


### PR DESCRIPTION
Signed-off-by: hemahg <hhg@redhat.com>

**What this PR does / why we need it**:

> fix the inconsistent behavior of the **Show More** state when you switch the selected client

**Which issue(s) this PR fixes** 

> Replace this comment with references to related issues.
> e.g. `fixes #<issue number>`

**Verification steps** 

> Attach a screenshot of the output.
> guidance on how to go the particular story.
> e.g. `point to the story with a text breadcrumb, something like "components > <component name> > <story name>”`

**Is there any work left / what's next** :

> Replace this comment with pending items that need to be covered in this PR or some pending items you are planning to do in the future PR.

**Special notes for your reviewer**:
