### PR TITLE
feat: Display partition log size according to topic

### DIFF
--- a/packages/consoledot-api/src/fetchers/fetchTopicsMetrics.ts
+++ b/packages/consoledot-api/src/fetchers/fetchTopicsMetrics.ts
@@ -26,7 +26,7 @@ export async function fetchTopicsMetrics({
   const response = await getMetricsByRangeQuery(id, duration, interval, [
     "kafka_topic:kafka_server_brokertopicmetrics_bytes_in_total:rate5m",
     "kafka_topic:kafka_server_brokertopicmetrics_bytes_out_total:rate5m",
-    "kafka_topic:kafka_log_log_size:sum",
+    "kas_topic_partition_log_size_bytes",
     "kafka_topic:kafka_server_brokertopicmetrics_messages_in_total:rate5m",
   ]);
 
@@ -40,9 +40,10 @@ export async function fetchTopicsMetrics({
 
   // Also filter for metrics about the selectedTopic, if specified
   const filteredMetrics = safeMetrics.filter((m) =>
+
     // filter for metrics for the selectedTopic, if needed
     selectedTopic !== undefined ? m.metric?.topic === selectedTopic : true
-  );
+);
 
   // get the unique topics we have metrics for in the selected time range
   const topics = Array.from(new Set(safeMetrics.map((m) => m.metric.topic)));
@@ -53,7 +54,7 @@ export async function fetchTopicsMetrics({
   const incomingMessageRate: TimeSeriesMetrics = {};
 
   filteredMetrics.forEach((m) => {
-    const { __name__: name, topic } = m.metric;
+    const { __name__: name, topic, partition_id } = m.metric;
 
     function addAggregatedTotalBytesTo(metric: TimeSeriesMetrics) {
       m.values.forEach(
@@ -63,12 +64,12 @@ export async function fetchTopicsMetrics({
     }
 
     function addAggregatePartitionBytes() {
-      const partition = bytesPerPartition[topic] || {};
+      const partition = bytesPerPartition[topic] || {};    
       m.values.forEach(
         ({ value, timestamp }) =>
           (partition[timestamp] = value + (partition[timestamp] || 0))
       );
-      bytesPerPartition[topic] = partition;
+      bytesPerPartition[topic +"/" + partition_id] = partition;
     }
 
     switch (name) {
@@ -78,7 +79,7 @@ export async function fetchTopicsMetrics({
       case "kafka_topic:kafka_server_brokertopicmetrics_bytes_out_total:rate5m":
         addAggregatedTotalBytesTo(bytesOutgoing);
         break;
-      case "kafka_topic:kafka_log_log_size:sum":
+      case "kas_topic_partition_log_size_bytes":
         addAggregatePartitionBytes();
         break;
       case "kafka_topic:kafka_server_brokertopicmetrics_messages_in_total:rate5m":

--- a/packages/locales/en/metrics.json
+++ b/packages/locales/en/metrics.json
@@ -52,14 +52,17 @@
   "topic_incoming_message_rate_y_axis": "Messages/seconds",
   "topic_metrics": "Topic metrics",
   "topic_metrics_help_text": "Bytes incoming and outgoing are the total bytes for all topics or total bytes for a selected topic in the $t(common:kafka) instance. This metric enables you to assess data transfer in and out of your $t(common:kafka) instance. To modify incoming and outgoing bytes, you can adjust topic message size or other topic properties as needed.",
-  "topic_partition_size": "Topic partition size",
-  "topic_partition_size_help_text": "Topic partition size is the log size for each partition in a selected topic. This metric enables you to assess the amount of data used in one or more topic partitions. To reduce the topic partition size, you can decrease the retention time or the retention size, or modify the cleanup policy as needed. You can also increase the number of partitions for the topic.",
-  "topic_partition_size_popover_header": "Topic partition size",
+  "topic_partition_size_help_text": "Partition size is the log size of a partition in a topic. This metric enables you to assess the amount of data used by partitions in the selected topic. To reduce partition sizes in a topic, you can decrease the retention time or the retention size, or modify the cleanup policy. You can also increase the number of partitions for the topic.",
+  "topic_partition_size_popover_header": "Partition size",
   "topics_filter_by_time": "Filter topic metrics by time range",
   "topics_filter_by_topic": "Filter topic metrics by topic name",
   "topics_refresh": "Refresh topic metrics",
   "total_bytes": "Bytes incoming and outgoing",
   "total_bytes_popover_header": "Bytes incoming and outgoing",
   "used_disk_space": "Used disk space",
-  "used_disk_space_help_text": "Used disk space is the amount of disk space used by the Kafka broker in the instance. This metric enables you to assess available disk space relative to the limit. To reduce used disk space, you can adjust topic retention time or other topic properties as needed."
+  "used_disk_space_help_text": "Used disk space is the amount of disk space used by the Kafka broker in the instance. This metric enables you to assess available disk space relative to the limit. To reduce used disk space, you can adjust topic retention time or other topic properties as needed.",
+  "filter-by-partitions": "Filter by partition",
+  "top10_partitions": "Top 10 partitions",
+  "top20_partitions": "Top 20 partitions",
+  "partition_size": "Partition size"
 }

--- a/packages/locales/en/metrics.json
+++ b/packages/locales/en/metrics.json
@@ -18,6 +18,7 @@
   "empty_state_no_topics_body": "Data will appear shortly after you start using topics.",
   "empty_state_no_topics_create_topic": "Create topic",
   "empty_state_no_topics_title": "No topic data",
+  "filter-by-partitions": "Filter by partition",
   "incoming_bytes": "Incoming bytes ({{topic}})",
   "incoming_bytes_all_topics": "Incoming bytes (all topics)",
   "kafka_instance_filter_by_time": "Filter $t(common:kafka) instance metrics by time range",
@@ -45,7 +46,10 @@
   "partition_limit_reached_description_1": "This Kafka instance has reached its maximum partition limit and might experience degraded performance.",
   "partition_limit_reached_description_2": "To create more partitions, consider migrating to a larger Kafka instance or splitting your workloads across multiple instances.",
   "partition_limit_reached_title": "This Kafka instance reached the partition limit",
+  "partition_size": "Partition size",
   "refreshing": "Getting data",
+  "top10_partitions": "Top 10 partitions",
+  "top20_partitions": "Top 20 partitions",
   "topic_incoming_message_rate": "Incoming message rate",
   "topic_incoming_message_rate_help_text": "Incoming message rate is the number of messages per second received by one or more topics in the $t(common:kafka) instance over time. This metric enables you to verify that messages are produced to topics and that producers are functioning properly. To modify the incoming messages per topic, you can adjust the corresponding producer as needed.",
   "topic_incoming_message_rate_popover_header": "Incoming messages",
@@ -60,9 +64,5 @@
   "total_bytes": "Bytes incoming and outgoing",
   "total_bytes_popover_header": "Bytes incoming and outgoing",
   "used_disk_space": "Used disk space",
-  "used_disk_space_help_text": "Used disk space is the amount of disk space used by the Kafka broker in the instance. This metric enables you to assess available disk space relative to the limit. To reduce used disk space, you can adjust topic retention time or other topic properties as needed.",
-  "filter-by-partitions": "Filter by partition",
-  "top10_partitions": "Top 10 partitions",
-  "top20_partitions": "Top 20 partitions",
-  "partition_size": "Partition size"
+  "used_disk_space_help_text": "Used disk space is the amount of disk space used by the Kafka broker in the instance. This metric enables you to assess available disk space relative to the limit. To reduce used disk space, you can adjust topic retention time or other topic properties as needed."
 }

--- a/packages/ui/src/components/Metrics/Metrics.tsx
+++ b/packages/ui/src/components/Metrics/Metrics.tsx
@@ -181,6 +181,8 @@ const ConnectedTopicsMetrics: VoidFunctionComponent<
     onDurationChange,
     onTopicChange,
     onRefresh,
+    onSelectPartition,
+    selectedPartition,
   } = useTopicsMetrics();
 
   return (
@@ -202,6 +204,8 @@ const ConnectedTopicsMetrics: VoidFunctionComponent<
       onSelectedTopic={onTopicChange}
       onDurationChange={onDurationChange}
       onCreateTopic={onCreateTopic}
+      onSelectedPartition={onSelectPartition}
+      selectedPartition={selectedPartition}
     />
   );
 };

--- a/packages/ui/src/components/Metrics/components/CardTopicsMetrics.tsx
+++ b/packages/ui/src/components/Metrics/components/CardTopicsMetrics.tsx
@@ -1,9 +1,17 @@
-import { Card, CardBody, CardTitle, Divider } from "@patternfly/react-core";
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  Divider,
+  Toolbar,
+  ToolbarContent,
+} from "@patternfly/react-core";
 import type { FunctionComponent } from "react";
-import { useTranslation } from "@rhoas/app-services-ui-components";
+import { useTranslation } from "react-i18next";
 import type {
   DurationOptions,
   PartitionBytesMetric,
+  PartitionSelect,
   TimeSeriesMetrics,
 } from "../types";
 import { CardBodyLoading } from "./CardBodyLoading";
@@ -15,6 +23,7 @@ import { EmptyStateNoMetricsData } from "./EmptyStateNoMetricsData";
 import { EmptyStateNoMetricsDataForSelection } from "./EmptyStateNoMetricsDataForSelection";
 import { EmptyStateNoTopics } from "./EmptyStateNoTopics";
 import { EmptyStateNoTopicSelected } from "./EmptyStateNoTopicSelected";
+import { FilterByPartition } from "./FilterByPartition";
 import type { ToolbarRefreshProps } from "./ToolbarRefresh";
 import { ToolbarTopicsMetrics } from "./ToolbarTopicsMetrics";
 
@@ -33,6 +42,8 @@ type CardTopicsMetricsProps = {
   onCreateTopic: () => void;
   onSelectedTopic: (topic: string | undefined) => void;
   onDurationChange: (duration: DurationOptions) => void;
+  onSelectedPartition: (value: PartitionSelect) => void;
+  selectedPartition: PartitionSelect;
 } & Omit<ToolbarRefreshProps, "ariaLabel">;
 
 export const CardTopicsMetrics: FunctionComponent<CardTopicsMetricsProps> = ({
@@ -53,6 +64,8 @@ export const CardTopicsMetrics: FunctionComponent<CardTopicsMetricsProps> = ({
   onRefresh,
   onSelectedTopic,
   onDurationChange,
+  selectedPartition,
+  onSelectedPartition,
 }) => {
   const { t } = useTranslation();
   const noTopics = topics.length === 0;
@@ -135,12 +148,21 @@ export const CardTopicsMetrics: FunctionComponent<CardTopicsMetricsProps> = ({
                 <Divider />
                 <PartitionSizeTitle />
                 <CardBody>
+                  <Toolbar>
+                    <ToolbarContent>
+                      <FilterByPartition
+                        onSetSelectedPartition={onSelectedPartition}
+                        partitionValue={selectedPartition}
+                      />
+                    </ToolbarContent>
+                  </Toolbar>
                   <ChartLogSizePerPartition
                     partitions={partitions}
                     topic={selectedTopic}
                     duration={duration}
                     isLoading={isLoading}
                     emptyState={chartEmptyState}
+                    selectedPartition={selectedPartition}
                   />
                 </CardBody>
               </>
@@ -202,7 +224,7 @@ const PartitionSizeTitle: FunctionComponent = () => {
   const { t } = useTranslation();
   return (
     <CardTitle component="h3">
-      {t("metrics:topic_partition_size")}{" "}
+      {t("metrics:partition_size")}{" "}
       <ChartPopover
         title={t("metrics:topic_partition_size_popover_header")}
         description={t("metrics:topic_partition_size_help_text")}

--- a/packages/ui/src/components/Metrics/components/ChartLogSizePerPartition.tsx
+++ b/packages/ui/src/components/Metrics/components/ChartLogSizePerPartition.tsx
@@ -1,7 +1,7 @@
 import type { ChartVoronoiContainerProps } from "@patternfly/react-charts";
+import { ChartLine } from "@patternfly/react-charts";
 import {
   Chart,
-  ChartArea,
   ChartAxis,
   ChartGroup,
   ChartLegend,
@@ -13,9 +13,9 @@ import {
   chart_color_cyan_300,
 } from "@patternfly/react-tokens";
 import type { FunctionComponent, ReactElement } from "react";
-import { useTranslation } from "@rhoas/app-services-ui-components";
+import { useTranslation } from "react-i18next";
 import { chartHeight, chartPadding } from "../consts";
-import type { PartitionBytesMetric } from "../types";
+import type { PartitionBytesMetric, PartitionSelect } from "../types";
 import { ChartSkeletonLoader } from "./ChartSkeletonLoader";
 import { useChartWidth } from "./useChartWidth";
 import {
@@ -48,89 +48,95 @@ export type ChartLogSizePerPartitionProps = {
   duration: number;
   isLoading: boolean;
   emptyState: ReactElement;
+  selectedPartition: PartitionSelect;
 };
 export const ChartLogSizePerPartition: FunctionComponent<
   ChartLogSizePerPartitionProps
-> = ({ partitions, topic, duration, isLoading, emptyState }) => {
-  const { t } = useTranslation();
-  const [containerRef, width] = useChartWidth();
+> = ({
+  partitions,
+  topic,
+  duration,
+  isLoading,
+  emptyState,
+  selectedPartition,
+}) => {
+    const { t } = useTranslation();
+    const [containerRef, width] = useChartWidth();
 
-  const itemsPerRow = width && width > 650 ? 6 : 3;
+    const { chartData, legendData, tickValues } = getChartData(
+      partitions,
+      topic,
+      duration,
+      selectedPartition
+    );
 
-  const { chartData, legendData, tickValues } = getChartData(
-    partitions,
-    topic,
-    duration
-  );
+    const hasMetrics = Object.keys(partitions).length > 0;
 
-  const hasMetrics = Object.keys(partitions).length > 0;
+    const showDate = shouldShowDate(duration);
 
-  const showDate = shouldShowDate(duration);
+    return (
+      <div ref={containerRef} style={{ height: "600px" }}>
+        {(() => {
+          switch (true) {
+            case isLoading:
+              return <ChartSkeletonLoader />;
+            case !hasMetrics:
+              return emptyState;
+            default: {
+              const labels: ChartVoronoiContainerProps["labels"] = ({ datum }) =>
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/restrict-template-expressions,@typescript-eslint/no-unsafe-argument
+                `${datum.name}: ${formatBytes(datum.y)}`;
 
-  return (
-    <div ref={containerRef}>
-      {(() => {
-        switch (true) {
-          case isLoading:
-            return <ChartSkeletonLoader />;
-          case !hasMetrics:
-            return emptyState;
-          default: {
-            const labels: ChartVoronoiContainerProps["labels"] = ({ datum }) =>
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/restrict-template-expressions,@typescript-eslint/no-unsafe-argument
-              `${datum.name}: ${formatBytes(datum.y)}`;
-
-            return (
-              <Chart
-                ariaTitle={t("metrics:log_size_per_partition")}
-                containerComponent={
-                  <ChartVoronoiContainer
-                    labels={labels}
-                    constrainToVisibleArea
-                  />
-                }
-                legendPosition="bottom-left"
-                legendComponent={
-                  <ChartLegend data={legendData} itemsPerRow={itemsPerRow} />
-                }
-                height={chartHeight}
-                padding={chartPadding}
-                themeColor={ChartThemeColor.multiOrdered}
-                width={width}
-                legendAllowWrap={true}
-              >
-                <ChartAxis
-                  label={"\n" + t("metrics:axis-label-time")}
-                  tickValues={tickValues}
-                  tickFormat={(d: number) =>
-                    dateToChartValue(d, {
-                      showDate,
-                    })
+              return (
+                <Chart
+                  ariaTitle={t("metrics:log_size_per_partition")}
+                  containerComponent={
+                    <ChartVoronoiContainer
+                      labels={labels}
+                      constrainToVisibleArea
+                    />
                   }
-                />
-                <ChartAxis
-                  label={"\n\n\n\n\n" + t("metrics:axis-label-bytes")}
-                  dependentAxis
-                  tickFormat={formatBytes}
-                />
-                <ChartGroup>
-                  {chartData.map((value, index) => (
-                    <ChartArea key={`chart-area-${index}`} data={value.area} />
-                  ))}
-                </ChartGroup>
-              </Chart>
-            );
+                  legendPosition="bottom-left"
+                  legendComponent={<ChartLegend data={legendData} />}
+                  height={chartHeight}
+                  padding={chartPadding}
+                  themeColor={ChartThemeColor.multiOrdered}
+                  width={width}
+                  legendAllowWrap={true}
+                >
+                  <ChartAxis
+                    label={"\n" + t("metrics:axis-label-time")}
+                    tickValues={tickValues}
+                    tickFormat={(d: number) =>
+                      dateToChartValue(d, {
+                        showDate,
+                      })
+                    }
+                  />
+                  <ChartAxis
+                    label={"\n\n\n\n\n" + t("metrics:axis-label-bytes")}
+                    dependentAxis
+                    tickFormat={formatBytes}
+                  />
+                  <ChartGroup>
+                    {chartData.map((value, index) => (
+                      <ChartLine key={`chart-area-${index}`} data={value.area} />
+                    ))}
+                  </ChartGroup>
+                </Chart>
+              );
+            }
           }
-        }
-      })()}
-    </div>
-  );
-};
+        })()}
+      </div>
+    );
+  };
 
 export function getChartData(
   partitions: PartitionBytesMetric,
   topic: string | undefined,
-  duration: number
+  duration: number,
+  selectedPartition: PartitionSelect
 ): {
   legendData: Array<LegendData>;
   chartData: Array<ChartData>;
@@ -138,19 +144,37 @@ export function getChartData(
 } {
   const legendData: Array<LegendData> = [];
   const chartData: Array<ChartData> = [];
-  Object.entries(partitions).map(([partition, dataMap], index) => {
-    const name = topic ? `${topic}: ${partition}` : partition;
-    const color = colors[index];
-    legendData.push({
-      name,
-    });
-    const area: Array<PartitionChartData> = [];
+  selectedPartition === "Top10"
+    ? Object.entries(partitions)
+      .slice(0, 10)
+      .map(([partition, dataMap], index) => {
+        const name = topic ? `${partition}` : partition;
+        const color = colors[index];
+        legendData.push({
+          name,
+        });
+        const area: Array<PartitionChartData> = [];
 
-    Object.entries(dataMap).map(([timestamp, value]) => {
-      area.push({ name, x: parseInt(timestamp, 10), y: value });
-    });
-    chartData.push({ color, area });
-  });
+        Object.entries(dataMap).map(([timestamp, value]) => {
+          area.push({ name, x: parseInt(timestamp, 10), y: value });
+        });
+        chartData.push({ color, area });
+      })
+    : Object.entries(partitions)
+      .slice(0, 20)
+      .map(([partition, dataMap], index) => {
+        const name = topic ? `${partition}` : partition;
+        const color = colors[index];
+        legendData.push({
+          name,
+        });
+        const area: Array<PartitionChartData> = [];
+
+        Object.entries(dataMap).map(([timestamp, value]) => {
+          area.push({ name, x: parseInt(timestamp, 10), y: value });
+        });
+        chartData.push({ color, area });
+      });
 
   const allTimestamps = Array.from(
     new Set(Object.values(partitions).flatMap((m) => Object.keys(m)))

--- a/packages/ui/src/components/Metrics/components/FilterByPartition.tsx
+++ b/packages/ui/src/components/Metrics/components/FilterByPartition.tsx
@@ -1,0 +1,64 @@
+import type { SelectProps } from "@patternfly/react-core";
+import {
+  Select,
+  SelectOption,
+  SelectVariant,
+  ToolbarItem,
+} from "@patternfly/react-core";
+import type { VoidFunctionComponent } from "react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { PartitionSelect } from "../types";
+
+type FilterByPartitionProps = {
+  partitionValue: PartitionSelect;
+  onSetSelectedPartition: (value: PartitionSelect) => void;
+};
+
+export const FilterByPartition: VoidFunctionComponent<
+  FilterByPartitionProps
+> = ({ partitionValue, onSetSelectedPartition }) => {
+  const { t } = useTranslation("metrics");
+
+  const [ispartitionSelectOpen, setIspartitionSelectOpen] =
+    useState<boolean>(false);
+
+  const onBrokerToggle = (ispartitionSelectOpen: boolean) => {
+    setIspartitionSelectOpen(ispartitionSelectOpen);
+  };
+
+  const partitionSelectOption: { [key in PartitionSelect]: string } = {
+    Top10: t("top10_partitions"),
+    Top20: t("top20_partitions"),
+  };
+
+  const onBrokerSelect: SelectProps["onSelect"] = (_, partition) => {
+    onSetSelectedPartition(partition as PartitionSelect);
+    setIspartitionSelectOpen(false);
+  };
+
+  const partitionOptions = () => {
+    return Object.entries(partitionSelectOption).map(([value, label]) => (
+      <SelectOption key={value} value={value}>
+        {label}
+      </SelectOption>
+    ));
+  };
+
+  return (
+    <ToolbarItem>
+      <Select
+        variant={SelectVariant.single}
+        isOpen={ispartitionSelectOpen}
+        onToggle={onBrokerToggle}
+        onSelect={onBrokerSelect}
+        selections={partitionValue}
+        position="left"
+        placeholderText={t("top10_partitions")}
+        aria-label={t("filter-by-partitions")}
+      >
+        {partitionOptions()}
+      </Select>
+    </ToolbarItem>
+  );
+};

--- a/packages/ui/src/components/Metrics/machines/TopicsMetricsMachine.ts
+++ b/packages/ui/src/components/Metrics/machines/TopicsMetricsMachine.ts
@@ -2,6 +2,7 @@ import { assign, createMachine } from "xstate";
 import type {
   GetTopicsMetricsResponse,
   PartitionBytesMetric,
+  PartitionSelect,
   TimeSeriesMetrics,
 } from "../types";
 import { DurationOptions } from "../types";
@@ -39,7 +40,7 @@ export type TopicsMetricsMachineContext = {
   // from the UI elements
   selectedTopic: string | undefined;
   duration: DurationOptions;
-
+  selectedPartition: PartitionSelect;
   // from the api
   kafkaTopics: string[];
   metricsTopics: string[];
@@ -55,7 +56,6 @@ export type TopicsMetricsMachineContext = {
 export const TopicsMetricsMachine = createMachine(
   {
     tsTypes: {} as import("./TopicsMetricsMachine.typegen").Typegen0,
-    predictableActionArguments: true,
     schema: {
       context: {} as TopicsMetricsMachineContext,
       events: {} as  // called when a new kafka id has been specified
@@ -67,7 +67,8 @@ export const TopicsMetricsMachine = createMachine(
 
         // from the UI elements
         | { type: "selectTopic"; topic: string | undefined }
-        | { type: "selectDuration"; duration: DurationOptions },
+        | { type: "selectDuration"; duration: DurationOptions }
+        | { type: "selectPartition"; value: PartitionSelect },
     },
     id: "topicsMetrics",
     context: {
@@ -76,6 +77,7 @@ export const TopicsMetricsMachine = createMachine(
       // from the UI elements
       selectedTopic: undefined,
       duration: DurationOptions.Last1hour,
+      selectedPartition: "Top10",
 
       // from the api
       kafkaTopics: [],
@@ -168,6 +170,9 @@ export const TopicsMetricsMachine = createMachine(
             actions: "setDuration",
             target: "callApi",
           },
+          selectPartition: {
+            actions: "setPartition",
+          },
         },
       },
     },
@@ -209,6 +214,7 @@ export const TopicsMetricsMachine = createMachine(
       setDuration: assign({
         duration: (_, event) => event.duration,
       }),
+      setPartition: assign((_, { value }) => ({ selectedPartition: value })),
     },
     guards: {
       canRetryFetching: (context) => context.fetchFailures < MAX_RETRIES,

--- a/packages/ui/src/components/Metrics/machines/TopicsMetricsMachine.typegen.ts
+++ b/packages/ui/src/components/Metrics/machines/TopicsMetricsMachine.typegen.ts
@@ -1,44 +1,79 @@
+// This file was automatically generated. Edits will be overwritten
 
-  // This file was automatically generated. Edits will be overwritten
-
-  export interface Typegen0 {
-        '@@xstate/typegen': true;
-        internalEvents: {
-          "xstate.after(1000)#topicsMetrics.callApi.failure": { type: "xstate.after(1000)#topicsMetrics.callApi.failure" };
-"xstate.after(1000)#topicsMetrics.initialLoading.failure": { type: "xstate.after(1000)#topicsMetrics.initialLoading.failure" };
-"xstate.init": { type: "xstate.init" };
-        };
-        invokeSrcNameMap: {
-          "api": "done.invoke.topicsMetrics.callApi.loading:invocation[0]" | "done.invoke.topicsMetrics.initialLoading.loading:invocation[0]" | "done.invoke.topicsMetrics.withResponse.refreshing:invocation[0]";
-        };
-        missingImplementations: {
-          actions: never;
-          delays: never;
-          guards: never;
-          services: "api";
-        };
-        eventsCausingActions: {
-          "incrementRetries": "fetchFail";
-"resetRetries": "refresh";
-"setDuration": "selectDuration";
-"setFetchTimestamp": "refresh" | "selectDuration" | "selectTopic" | "xstate.init";
-"setMetrics": "fetchSuccess";
-"setPartition": "selectPartition";
-"setTopic": "selectTopic";
-        };
-        eventsCausingDelays: {
-          
-        };
-        eventsCausingGuards: {
-          "canRetryFetching": "xstate.after(1000)#topicsMetrics.callApi.failure" | "xstate.after(1000)#topicsMetrics.initialLoading.failure";
-"isJustCreated": "fetchSuccess";
-        };
-        eventsCausingServices: {
-          "api": "refresh" | "selectDuration" | "selectTopic" | "xstate.after(1000)#topicsMetrics.callApi.failure" | "xstate.after(1000)#topicsMetrics.initialLoading.failure" | "xstate.init";
-        };
-        matchesStates: "callApi" | "callApi.failure" | "callApi.loading" | "criticalFail" | "initialLoading" | "initialLoading.failure" | "initialLoading.loading" | "justCreated" | "withResponse" | "withResponse.idle" | "withResponse.refreshing" | { "callApi"?: "failure" | "loading";
-"initialLoading"?: "failure" | "loading";
-"withResponse"?: "idle" | "refreshing"; };
-        tags: "failed" | "initialLoading" | "justCreated" | "loading" | "refreshing" | "withResponse";
-      }
-  
+export interface Typegen0 {
+  "@@xstate/typegen": true;
+  internalEvents: {
+    "xstate.after(1000)#topicsMetrics.callApi.failure": {
+      type: "xstate.after(1000)#topicsMetrics.callApi.failure";
+    };
+    "xstate.after(1000)#topicsMetrics.initialLoading.failure": {
+      type: "xstate.after(1000)#topicsMetrics.initialLoading.failure";
+    };
+    "xstate.init": { type: "xstate.init" };
+  };
+  invokeSrcNameMap: {
+    api:
+      | "done.invoke.topicsMetrics.callApi.loading:invocation[0]"
+      | "done.invoke.topicsMetrics.initialLoading.loading:invocation[0]"
+      | "done.invoke.topicsMetrics.withResponse.refreshing:invocation[0]";
+  };
+  missingImplementations: {
+    actions: never;
+    delays: never;
+    guards: never;
+    services: "api";
+  };
+  eventsCausingActions: {
+    incrementRetries: "fetchFail";
+    resetRetries: "refresh";
+    setDuration: "selectDuration";
+    setFetchTimestamp:
+      | "refresh"
+      | "selectDuration"
+      | "selectTopic"
+      | "xstate.init";
+    setMetrics: "fetchSuccess";
+    setPartition: "selectPartition";
+    setTopic: "selectTopic";
+  };
+  eventsCausingDelays: {};
+  eventsCausingGuards: {
+    canRetryFetching:
+      | "xstate.after(1000)#topicsMetrics.callApi.failure"
+      | "xstate.after(1000)#topicsMetrics.initialLoading.failure";
+    isJustCreated: "fetchSuccess";
+  };
+  eventsCausingServices: {
+    api:
+      | "refresh"
+      | "selectDuration"
+      | "selectTopic"
+      | "xstate.after(1000)#topicsMetrics.callApi.failure"
+      | "xstate.after(1000)#topicsMetrics.initialLoading.failure"
+      | "xstate.init";
+  };
+  matchesStates:
+    | "callApi"
+    | "callApi.failure"
+    | "callApi.loading"
+    | "criticalFail"
+    | "initialLoading"
+    | "initialLoading.failure"
+    | "initialLoading.loading"
+    | "justCreated"
+    | "withResponse"
+    | "withResponse.idle"
+    | "withResponse.refreshing"
+    | {
+        callApi?: "failure" | "loading";
+        initialLoading?: "failure" | "loading";
+        withResponse?: "idle" | "refreshing";
+      };
+  tags:
+    | "failed"
+    | "initialLoading"
+    | "justCreated"
+    | "loading"
+    | "refreshing"
+    | "withResponse";
+}

--- a/packages/ui/src/components/Metrics/machines/TopicsMetricsMachine.typegen.ts
+++ b/packages/ui/src/components/Metrics/machines/TopicsMetricsMachine.typegen.ts
@@ -1,78 +1,44 @@
-// This file was automatically generated. Edits will be overwritten
 
-export interface Typegen0 {
-  "@@xstate/typegen": true;
-  internalEvents: {
-    "xstate.after(1000)#topicsMetrics.callApi.failure": {
-      type: "xstate.after(1000)#topicsMetrics.callApi.failure";
-    };
-    "xstate.after(1000)#topicsMetrics.initialLoading.failure": {
-      type: "xstate.after(1000)#topicsMetrics.initialLoading.failure";
-    };
-    "xstate.init": { type: "xstate.init" };
-  };
-  invokeSrcNameMap: {
-    api:
-      | "done.invoke.topicsMetrics.callApi.loading:invocation[0]"
-      | "done.invoke.topicsMetrics.initialLoading.loading:invocation[0]"
-      | "done.invoke.topicsMetrics.withResponse.refreshing:invocation[0]";
-  };
-  missingImplementations: {
-    actions: never;
-    delays: never;
-    guards: never;
-    services: "api";
-  };
-  eventsCausingActions: {
-    incrementRetries: "fetchFail";
-    resetRetries: "refresh";
-    setDuration: "selectDuration";
-    setFetchTimestamp:
-      | "refresh"
-      | "selectDuration"
-      | "selectTopic"
-      | "xstate.init";
-    setMetrics: "fetchSuccess";
-    setTopic: "selectTopic";
-  };
-  eventsCausingDelays: {};
-  eventsCausingGuards: {
-    canRetryFetching:
-      | "xstate.after(1000)#topicsMetrics.callApi.failure"
-      | "xstate.after(1000)#topicsMetrics.initialLoading.failure";
-    isJustCreated: "fetchSuccess";
-  };
-  eventsCausingServices: {
-    api:
-      | "refresh"
-      | "selectDuration"
-      | "selectTopic"
-      | "xstate.after(1000)#topicsMetrics.callApi.failure"
-      | "xstate.after(1000)#topicsMetrics.initialLoading.failure"
-      | "xstate.init";
-  };
-  matchesStates:
-    | "callApi"
-    | "callApi.failure"
-    | "callApi.loading"
-    | "criticalFail"
-    | "initialLoading"
-    | "initialLoading.failure"
-    | "initialLoading.loading"
-    | "justCreated"
-    | "withResponse"
-    | "withResponse.idle"
-    | "withResponse.refreshing"
-    | {
-        callApi?: "failure" | "loading";
-        initialLoading?: "failure" | "loading";
-        withResponse?: "idle" | "refreshing";
-      };
-  tags:
-    | "failed"
-    | "initialLoading"
-    | "justCreated"
-    | "loading"
-    | "refreshing"
-    | "withResponse";
-}
+  // This file was automatically generated. Edits will be overwritten
+
+  export interface Typegen0 {
+        '@@xstate/typegen': true;
+        internalEvents: {
+          "xstate.after(1000)#topicsMetrics.callApi.failure": { type: "xstate.after(1000)#topicsMetrics.callApi.failure" };
+"xstate.after(1000)#topicsMetrics.initialLoading.failure": { type: "xstate.after(1000)#topicsMetrics.initialLoading.failure" };
+"xstate.init": { type: "xstate.init" };
+        };
+        invokeSrcNameMap: {
+          "api": "done.invoke.topicsMetrics.callApi.loading:invocation[0]" | "done.invoke.topicsMetrics.initialLoading.loading:invocation[0]" | "done.invoke.topicsMetrics.withResponse.refreshing:invocation[0]";
+        };
+        missingImplementations: {
+          actions: never;
+          delays: never;
+          guards: never;
+          services: "api";
+        };
+        eventsCausingActions: {
+          "incrementRetries": "fetchFail";
+"resetRetries": "refresh";
+"setDuration": "selectDuration";
+"setFetchTimestamp": "refresh" | "selectDuration" | "selectTopic" | "xstate.init";
+"setMetrics": "fetchSuccess";
+"setPartition": "selectPartition";
+"setTopic": "selectTopic";
+        };
+        eventsCausingDelays: {
+          
+        };
+        eventsCausingGuards: {
+          "canRetryFetching": "xstate.after(1000)#topicsMetrics.callApi.failure" | "xstate.after(1000)#topicsMetrics.initialLoading.failure";
+"isJustCreated": "fetchSuccess";
+        };
+        eventsCausingServices: {
+          "api": "refresh" | "selectDuration" | "selectTopic" | "xstate.after(1000)#topicsMetrics.callApi.failure" | "xstate.after(1000)#topicsMetrics.initialLoading.failure" | "xstate.init";
+        };
+        matchesStates: "callApi" | "callApi.failure" | "callApi.loading" | "criticalFail" | "initialLoading" | "initialLoading.failure" | "initialLoading.loading" | "justCreated" | "withResponse" | "withResponse.idle" | "withResponse.refreshing" | { "callApi"?: "failure" | "loading";
+"initialLoading"?: "failure" | "loading";
+"withResponse"?: "idle" | "refreshing"; };
+        tags: "failed" | "initialLoading" | "justCreated" | "loading" | "refreshing" | "withResponse";
+      }
+  

--- a/packages/ui/src/components/Metrics/storiesHelpers.ts
+++ b/packages/ui/src/components/Metrics/storiesHelpers.ts
@@ -77,11 +77,29 @@ export const getTopicsMetrics = ({
       incomingMessageRate: makeMetrics(duration, 3, 8, 10, offset),
       bytesPerPartition: selectedTopic
         ? {
-            "partition 1": makeMetrics(duration, 0, 2, 10 ** 7, offset),
-            "partition 2": makeMetrics(duration, 0, 4, 10 ** 7, offset),
-            "partition 3": makeMetrics(duration, 0, 6, 10 ** 7, offset),
-          }
-        : {},
+          "0": makeMetrics(duration, 0, 2, 10 ** 7, offset),
+          "1": makeMetrics(duration, 0, 4, 10 ** 7, offset),
+          "2": makeMetrics(duration, 0, 6, 10 ** 7, offset),
+          "3": makeMetrics(duration, 0, 8, 10 ** 7, offset),
+          "4": makeMetrics(duration, 0, 12, 10 ** 7, offset),
+          "5": makeMetrics(duration, 0, 20, 10 ** 7, offset),
+          "6": makeMetrics(duration, 0, 18, 10 ** 7, offset),
+          "7": makeMetrics(duration, 0, 13, 10 ** 7, offset),
+          "8": makeMetrics(duration, 0, 7, 10 ** 7, offset),
+          "9": makeMetrics(duration, 0, 5, 10 ** 7, offset),
+          "10": makeMetrics(duration, 0, 24, 10 ** 7, offset),
+          "11": makeMetrics(duration, 0, 29, 10 ** 7, offset),
+          "12": makeMetrics(duration, 0, 23, 10 ** 7, offset),
+          "13": makeMetrics(duration, 0, 32, 10 ** 7, offset),
+          "14": makeMetrics(duration, 0, 32, 10 ** 7, offset),
+          "15": makeMetrics(duration, 0, 30, 10 ** 7, offset),
+          "16": makeMetrics(duration, 0, 24, 10 ** 7, offset),
+          "17": makeMetrics(duration, 0, 27, 10 ** 7, offset),
+          "18": makeMetrics(duration, 0, 27, 10 ** 7, offset),
+          "19": makeMetrics(duration, 0, 40, 10 ** 7, offset),
+          "20": makeMetrics(duration, 0, 26, 10 ** 7, offset),
+        }
+      : {},
     },
     waitLengthMs
   );
@@ -120,9 +138,15 @@ export const getTopicsMetricsWithDeletedTopicMetric = ({
         : {},
       bytesPerPartition: hasMetrics
         ? {
-            "partition 1": makeMetrics(duration, 0, 2, 10 ** 7, offset),
-            "partition 2": makeMetrics(duration, 0, 4, 10 ** 7, offset),
-            "partition 3": makeMetrics(duration, 0, 6, 10 ** 7, offset),
+          "0": makeMetrics(duration, 0, 2, 10 ** 7, offset),
+          "1": makeMetrics(duration, 0, 4, 10 ** 7, offset),
+          "2": makeMetrics(duration, 0, 6, 10 ** 7, offset),
+          "3": makeMetrics(duration, 0, 8, 10 ** 7, offset),
+          "4": makeMetrics(duration, 0, 12, 10 ** 7, offset),
+          "5": makeMetrics(duration, 0, 20, 10 ** 7, offset),
+          "6": makeMetrics(duration, 0, 18, 10 ** 7, offset),
+          "7": makeMetrics(duration, 0, 13, 10 ** 7, offset),
+          "8": makeMetrics(duration, 0, 12, 10 ** 7, offset),
           }
         : {},
     },
@@ -161,9 +185,15 @@ export const getTopicsMetricsOneTopic = ({
       ),
       incomingMessageRate: makeMetrics(duration, 3, 8, 10, offset),
       bytesPerPartition: {
-        "partition 1": makeMetrics(duration, 0, 2, 10 ** 7, offset),
-        "partition 2": makeMetrics(duration, 0, 4, 10 ** 7, offset),
-        "partition 3": makeMetrics(duration, 0, 6, 10 ** 7, offset),
+        "0": makeMetrics(duration, 0, 2, 10 ** 7, offset),
+        "1": makeMetrics(duration, 0, 4, 10 ** 7, offset),
+        "2": makeMetrics(duration, 0, 6, 10 ** 7, offset),
+        "3": makeMetrics(duration, 0, 8, 10 ** 7, offset),
+        "4": makeMetrics(duration, 0, 12, 10 ** 7, offset),
+        "5": makeMetrics(duration, 0, 20, 10 ** 7, offset),
+        "6": makeMetrics(duration, 0, 18, 10 ** 7, offset),
+        "7": makeMetrics(duration, 0, 13, 10 ** 7, offset),
+        "8": makeMetrics(duration, 0, 12, 10 ** 7, offset),
       },
     },
     waitLengthMs

--- a/packages/ui/src/components/Metrics/types.ts
+++ b/packages/ui/src/components/Metrics/types.ts
@@ -1,7 +1,7 @@
 import type { CardKafkaInstanceMetricsLimits } from "./components";
 
 export type TimeSeriesMetrics = { [timestamp: string]: number };
-export type PartitionBytesMetric = { [partition: string]: TimeSeriesMetrics };
+export type PartitionBytesMetric = { [partition: string ]: TimeSeriesMetrics };
 
 export enum DurationOptions {
   Last5minutes = 5,
@@ -37,3 +37,5 @@ export type GetMetricsKpiResponse = {
   consumerGroups: number;
   topicPartitionsLimit: number;
 };
+
+export type PartitionSelect = "Top10" | "Top20";

--- a/packages/ui/src/components/Metrics/useTopicsMetrics.tsx
+++ b/packages/ui/src/components/Metrics/useTopicsMetrics.tsx
@@ -1,8 +1,8 @@
 import { useSelector } from "@xstate/react";
 import { useCallback, useContext, useMemo } from "react";
 import type { TopicsMetricsMachineContext } from "./machines";
-import { TopicsMetricsContext } from "./TopicsMetricsProvider";
-import type { DurationOptions } from "./types";
+import type { DurationOptions, PartitionSelect } from "./types";
+import { TopicsMetricsContext } from './TopicsMetricsProvider';
 
 type SelectorReturn = TopicsMetricsMachineContext & {
   isInitialLoading: boolean;
@@ -30,6 +30,7 @@ export function useTopicsMetrics() {
     isFailed,
     isJustCreated,
     lastUpdated,
+    selectedPartition,
   } = useSelector<typeof service, SelectorReturn>(
     service,
     useCallback(
@@ -66,6 +67,12 @@ export function useTopicsMetrics() {
     return topics;
   }, [kafkaTopics, metricsTopics]);
 
+  const onSelectPartition = useCallback(
+    (value: PartitionSelect) =>
+      service.send({ type: "selectPartition", value }),
+    [service]
+  );
+
   return {
     isInitialLoading,
     isLoading,
@@ -83,5 +90,7 @@ export function useTopicsMetrics() {
     onTopicChange,
     onDurationChange,
     onRefresh,
+    onSelectPartition,
+    selectedPartition,
   };
 }


### PR DESCRIPTION
Signed-off-by: hemahg <hhg@redhat.com>

**What this PR does / why we need it**:

- [x]  Add toggle to filter between top 10 and 20 partition
- [x] update partition log size according to broker 

**Which issue(s) this PR fixes** 

> Replace this comment with references to related issues.
>  fixes https://issues.redhat.com/browse/MGDX-259

**Verification steps** 

> Attach a screenshot of the output.
> guidance on how to go the particular story.
> e.g. `point to the story with a text breadcrumb, something like "components > <component name> > <story name>”`

**Is there any work left / what's next** :

> Replace this comment with pending items that need to be covered in this PR or some pending items you are planning to do in the future PR.

**Special notes for your reviewer**:
