### PR TITLE
chore: Maintain the same naming consistency of client type throughout the sample code snippet component

### DIFF
--- a/packages/locales/en/kafka.json
+++ b/packages/locales/en/kafka.json
@@ -205,7 +205,7 @@
     "spring_boot_consumer_configuration": "Consumer configuration",
     "spring_boot_consumer_configuration_description": "Use the following code to create a listener container required by the example Spring Boot consumer.",
     "spring_boot_consumer_description": "Use the following code to run the example Spring Boot consumer.",
-    "spring_boot_listener": "Listener",
+    "spring_boot_listener": "Consumer listener",
     "spring_boot_listener_description": "Use the following code to run the listener container required by the example Spring Boot consumer.",
     "spring_boot_sample_consumer_code_description": "Use the following code snippets to create an example Spring Boot client that consumes messages from your Kafka instance."
   },

--- a/packages/locales/en/kafka.json
+++ b/packages/locales/en/kafka.json
@@ -190,7 +190,7 @@
       "java": "Java",
       "python": "Python",
       "quarkus": "Quarkus",
-      "spring_boot": "Spring boot"
+      "spring_boot": "Spring Boot"
     },
     "code_snippet_description_1": "Use our sample code snippets to learn how to connect client applications to your Kafka instance. ",
     "code_snippet_description_2": "First, modify our configuration code to make a secure connection to your Kafka instance. Specify details such as your Kafka host (bootstrap server) and service account credentials. Then, use our application code to create example producers and consumers that interact with your instance.",

--- a/packages/ui/src/components/KafkaInstanceDrawer/components/KafkaSampleCode.tsx
+++ b/packages/ui/src/components/KafkaInstanceDrawer/components/KafkaSampleCode.tsx
@@ -54,6 +54,13 @@ export const KafkaSampleCode: VoidFunctionComponent<KafkaSampleCodeProps> = ({
 
   const [clientSelect, setClientSelect] = useState<ClientType>("java");
 
+  const clientProvider: { [provider in ClientType]: string } = {
+    java: t("sample_code.clients.java"),
+    python: t("sample_code.clients.python"),
+    quarkus: t("sample_code.clients.quarkus"),
+    springboot: t("sample_code.clients.spring_boot"),
+  };
+
   return (
     <div className="mas--details__drawer--tab-content">
       <TextContent className="pf-u-pb-sm">
@@ -65,28 +72,28 @@ export const KafkaSampleCode: VoidFunctionComponent<KafkaSampleCodeProps> = ({
         </Text>
         <ToggleGroup>
           <ToggleGroupItem
-            text={t("sample_code.clients.java")}
+            text={clientProvider["java"]}
             value="java"
             buttonId="java"
             isSelected={clientSelect === "java"}
             onChange={() => setClientSelect("java")}
           />
           <ToggleGroupItem
-            text={t("sample_code.clients.python")}
+            text={clientProvider["python"]}
             value="python"
             buttonId="python"
             isSelected={clientSelect === "python"}
             onChange={() => setClientSelect("python")}
           />
           <ToggleGroupItem
-            text={t("sample_code.clients.quarkus")}
+            text={clientProvider["quarkus"]}
             value="quarkus"
             buttonId="quarkus"
             isSelected={clientSelect === "quarkus"}
             onChange={() => setClientSelect("quarkus")}
           />
           <ToggleGroupItem
-            text={t("sample_code.clients.spring_boot")}
+            text={clientProvider["springboot"]}
             value="springboot"
             buttonId="springboot"
             isSelected={clientSelect === "springboot"}
@@ -172,7 +179,7 @@ export const KafkaSampleCode: VoidFunctionComponent<KafkaSampleCodeProps> = ({
                 ns={"kafka"}
                 i18nKey={"sample_code.sample_producer_code_description"}
                 values={{
-                  client_type: clientSelect,
+                  client_type: clientProvider[clientSelect],
                 }}
               />
             </Text>
@@ -255,7 +262,7 @@ export const KafkaSampleCode: VoidFunctionComponent<KafkaSampleCodeProps> = ({
                 ns={"kafka"}
                 i18nKey={"sample_code.sample_consumer_code_description"}
                 values={{
-                  client_type: clientSelect,
+                  client_type: clientProvider[clientSelect],
                 }}
               />
             </Text>

--- a/packages/ui/src/components/KafkaInstanceDrawer/components/KafkaSampleCode.tsx
+++ b/packages/ui/src/components/KafkaInstanceDrawer/components/KafkaSampleCode.tsx
@@ -238,6 +238,9 @@ export const KafkaSampleCode: VoidFunctionComponent<KafkaSampleCodeProps> = ({
             <Text component={TextVariants.small}>
               {t("sample_code.spring_boot_listener_description")}
             </Text>
+            <Text component={TextVariants.small}>
+              {t("sample_code.bracket_text")}
+            </Text>
             <SampleCodeSnippet
               codeBlockCode={springBootListenerCodeBlock}
               expandableCode={springBootListenerExpandableBlock}
@@ -266,6 +269,10 @@ export const KafkaSampleCode: VoidFunctionComponent<KafkaSampleCodeProps> = ({
                 }}
               />
             </Text>
+            {clientSelect === "quarkus" ? null :
+              <Text component={TextVariants.small}>
+                {t("sample_code.bracket_text")}
+              </Text>}
             {(() => {
               switch (clientSelect) {
                 case "java":


### PR DESCRIPTION
…e sample code component

Signed-off-by: hemahg <hhg@redhat.com>

**What this PR does / why we need it**:

> Maintain the same naming consistency of client type throughout the sample code snippet component

**Which issue(s) this PR fixes** 

> This issue was spotted on the sprint Demo

**Verification steps** 

https://63c984f3273772562ae72406-eylnsegzhs.chromatic.com/?path=/story/components-kafkainstancedrawer-components-kafkasamplecode--sample-code-snippet
