### PR TITLE
chore: Rename permissions routes

### DIFF
--- a/apps/consoledot-rhosak/src/routes/data-plane/DataPlaneRoutes.tsx
+++ b/apps/consoledot-rhosak/src/routes/data-plane/DataPlaneRoutes.tsx
@@ -4,7 +4,7 @@ import { Redirect, Route, Switch } from "react-router-dom";
 import { ControlPlaneRouteRoot } from "../control-plane/routesConsts";
 import { RedirectOnGateError } from "../RedirectOnGateError";
 import {
-  AclsRoute,
+  PermissionsRoute,
   ConsumerGroupsRoute,
   DashboardRoute,
   SettingsRoute,
@@ -21,8 +21,8 @@ import {
   TopicConsumerGroupViewPartitionRoute,
   TopicDeleteRoute,
   TopicEditPropertiesRoute,
-  EditPermissionsRoute,
-  ManagePermissionsRoute,
+  PermissionsEditRoute,
+  PermissionsSelectAccountRoute,
 } from "./routes";
 
 import { DataPlaneRoutePath, DataPlaneTopicRoutePath } from "./routesConsts";
@@ -64,7 +64,7 @@ const viewTopicPartitionConsumerGroupHref = (
 export const managePermissionsHref = (id: string) =>
   `${instanceDetailsHref(id)}/acls/select-account`;
 
-export const editPermissionsHref = (id: string, selectedAccount: string) =>
+const editPermissionsHref = (id: string, selectedAccount: string) =>
   `${instanceDetailsHref(
     id
   )}/acls/select-account/${selectedAccount}/edit-permissions`;
@@ -91,7 +91,8 @@ export const DataPlaneRoutes: VoidFunctionComponent = () => {
 
           <Route path={`${DataPlaneRoutePath}/acls`}>
             <Route path={`${DataPlaneRoutePath}/acls/select-account`}>
-              <ManagePermissionsRoute
+              <PermissionsSelectAccountRoute
+                editPermissionsHref={editPermissionsHref}
                 instancesHref={"/kafkas"}
                 managePermissionsHref={permissionsModalHref}
               />
@@ -99,14 +100,16 @@ export const DataPlaneRoutes: VoidFunctionComponent = () => {
             <Route
               path={`${DataPlaneRoutePath}/acls/select-account/:selectedAccount/edit-permissions`}
             >
-              <EditPermissionsRoute
+              <PermissionsEditRoute
+                editPermissionsHref={editPermissionsHref}
                 instancesHref={"/kafkas"}
                 managePermissionsHref={permissionsModalHref}
               />
             </Route>
-            <AclsRoute
+            <PermissionsRoute
               instancesHref={"/kafkas"}
               managePermissionsHref={managePermissionsHref}
+              editPermissionsHref={editPermissionsHref}
             />
           </Route>
 

--- a/apps/consoledot-rhosak/src/routes/data-plane/routes/PermissionsEditRoute.tsx
+++ b/apps/consoledot-rhosak/src/routes/data-plane/routes/PermissionsEditRoute.tsx
@@ -18,7 +18,8 @@ import type {
 } from "../routesConsts";
 import { DataPlanePermissionsRoutePath } from "../routesConsts";
 import { useDataPlaneGate } from "../useDataPlaneGate";
-export const EditPermissionsRoute: VoidFunctionComponent<
+
+export const PermissionsEditRoute: VoidFunctionComponent<
   DataPlanePermissionsNavigationProps
 > = ({ managePermissionsHref }) => {
   const { instance } = useDataPlaneGate();

--- a/apps/consoledot-rhosak/src/routes/data-plane/routes/PermissionsRoute.tsx
+++ b/apps/consoledot-rhosak/src/routes/data-plane/routes/PermissionsRoute.tsx
@@ -15,12 +15,11 @@ import { useHistory } from "react-router-dom";
 import type { DataPlanePermissionsNavigationProps } from "../routesConsts";
 import { addNotification } from "@redhat-cloud-services/frontend-components-notifications";
 import { useDispatch } from "react-redux";
-import { editPermissionsHref } from "../DataPlaneRoutes";
 import { useDataPlaneGate } from "../useDataPlaneGate";
 
-export const AclsRoute: VoidFunctionComponent<
+export const PermissionsRoute: VoidFunctionComponent<
   DataPlanePermissionsNavigationProps
-> = ({ instancesHref, managePermissionsHref }) => {
+> = ({ instancesHref, managePermissionsHref, editPermissionsHref }) => {
   const { page, perPage, setPagination, setPaginationQuery } =
     usePaginationSearchParams();
   const { instance } = useDataPlaneGate();

--- a/apps/consoledot-rhosak/src/routes/data-plane/routes/PermissionsSelectAccountRoute.tsx
+++ b/apps/consoledot-rhosak/src/routes/data-plane/routes/PermissionsSelectAccountRoute.tsx
@@ -5,13 +5,13 @@ import { PrincipalType } from "ui";
 import { useHistory } from "react-router-dom";
 import type { DataPlanePermissionsNavigationProps } from "../routesConsts";
 import { SelectAccount } from "ui";
-import { editPermissionsHref } from "../DataPlaneRoutes";
 import { useChrome } from "@redhat-cloud-services/frontend-components/useChrome";
 import { useServiceAccounts, useUserAccounts } from "consoledot-api";
 import { useDataPlaneGate } from "../useDataPlaneGate";
-export const ManagePermissionsRoute: VoidFunctionComponent<
+
+export const PermissionsSelectAccountRoute: VoidFunctionComponent<
   DataPlanePermissionsNavigationProps
-> = ({ managePermissionsHref }) => {
+> = ({ managePermissionsHref, editPermissionsHref }) => {
   const [loggedInUser, setCurrentlyLoggedInUser] = useState<
     string | undefined
   >();

--- a/apps/consoledot-rhosak/src/routes/data-plane/routes/index.ts
+++ b/apps/consoledot-rhosak/src/routes/data-plane/routes/index.ts
@@ -1,4 +1,4 @@
-export * from "./AclsRoute";
+export * from "./PermissionsRoute";
 export * from "./TopicsRoute";
 export * from "./SettingsRoute";
 export * from "./DashboardRoute";
@@ -16,5 +16,5 @@ export * from "./TopicConsumerGroupResetOffsetRoute";
 export * from "./TopicConsumerGroupViewPartitionRoute";
 export * from "./TopicDeleteRoute";
 export * from "./TopicEditPropertiesRoute";
-export * from "./EditPermissionsRoute";
-export * from "./ManagePermissionsRoute";
+export * from "./PermissionsEditRoute";
+export * from "./PermissionsSelectAccountRoute";

--- a/apps/consoledot-rhosak/src/routes/data-plane/routesConsts.ts
+++ b/apps/consoledot-rhosak/src/routes/data-plane/routesConsts.ts
@@ -31,12 +31,6 @@ export const DataPlaneTopicConsumerGroupRoutePath =
 export const DataPlanePermissionsRoutePath =
   `${ControlPlaneRouteRoot}/:id/details/acls/select-account/:selectedAccount` as const;
 
-export const DataPlaneSelectAccountsRoutePath =
-  `${ControlPlaneRouteRoot}/:id/details/acls/select-account` as const;
-
-export const DataPlanePermissionsTableRoutePath =
-  `${ControlPlaneRouteRoot}/:id/details/acls` as const;
-
 export type DataPlaneNavigationProps = {
   instanceDetailsHref: (instanceId: string) => string;
   instanceTopicsHref: (instanceId: string) => string;
@@ -75,4 +69,5 @@ export type DataPlaneTopicConsumerGroupNavigationsProps = {
 
 export type DataPlanePermissionsNavigationProps = {
   managePermissionsHref: (instanceId: string) => string;
+  editPermissionsHref: (instanceId: string, selectedAccount: string) => string;
 } & ControlPlaneNavigationProps;


### PR DESCRIPTION
- Rename routes to follow the given pattern
- Remove unused Route paths
- Remove imports of the `editPermissionsHref` and pass it as props instead