### PR TITLE
chore: Get availability zone from instance type

### DIFF
--- a/packages/consoledot-api/src/transformers/kafkaRequestToKafkaInstanceEnhanched.ts
+++ b/packages/consoledot-api/src/transformers/kafkaRequestToKafkaInstanceEnhanched.ts
@@ -46,6 +46,7 @@ export function kafkaRequestToKafkaInstanceEnhanched(
     version: instance.version || "",
     bootstrapUrl: instance.bootstrap_server_host,
     adminUrl: instance.admin_api_server_url,
+    az: instance.multi_az == true ? "multi" : "single",
   };
 
   // update the billing info

--- a/packages/locales/en/kafka.json
+++ b/packages/locales/en/kafka.json
@@ -139,6 +139,7 @@
   "empty_state_no_results_found_title": "No results found",
   "fields": {
     "adminUrl": "URL for Kafka Instance API",
+    "availabilityZone": "Availability Zones",
     "billing": "Billing",
     "bootstrapUrl": "Bootstrap server",
     "connectionRate": "Connection rate",

--- a/packages/ui-models/src/models/kafka.ts
+++ b/packages/ui-models/src/models/kafka.ts
@@ -26,6 +26,7 @@ export type Kafka = {
   connectionRate: number | undefined;
   messageSize: Bytes | undefined;
   billing: "prepaid" | MarketplaceSubscription | undefined;
+  az: AZ;
 
   version: string;
 
@@ -101,7 +102,7 @@ export const Statuses = [
   "resuming",
 ] as const;
 
-export type Status = typeof Statuses[number];
+export type Status = (typeof Statuses)[number];
 
 export const CreatingStatuses: readonly Status[] = [
   "accepted",

--- a/packages/ui/src/components/KafkaInstances/storiesHelper.ts
+++ b/packages/ui/src/components/KafkaInstances/storiesHelper.ts
@@ -29,6 +29,7 @@ export const instances: Kafka[] = [
     version: "1.2.3",
     bootstrapUrl: undefined,
     adminUrl: undefined,
+    az: "multi",
   },
   {
     id: "2",
@@ -53,6 +54,7 @@ export const instances: Kafka[] = [
     version: "1.2.3",
     bootstrapUrl: undefined,
     adminUrl: undefined,
+    az: "single",
   },
   {
     id: "3",
@@ -77,6 +79,7 @@ export const instances: Kafka[] = [
     version: "1.2.3",
     bootstrapUrl: undefined,
     adminUrl: undefined,
+    az: "single",
   },
   {
     id: "4",
@@ -101,5 +104,6 @@ export const instances: Kafka[] = [
     version: "1.2.3",
     bootstrapUrl: undefined,
     adminUrl: undefined,
+    az: "single",
   },
 ];

--- a/packages/ui/src/hooks/useKafkaLabels.ts
+++ b/packages/ui/src/hooks/useKafkaLabels.ts
@@ -67,6 +67,7 @@ export function useKafkaLabels() {
     adminUrl: t("fields.adminUrl"),
     bootstrapUrl: t("fields.bootstrapUrl"),
     version: t("fields.version"),
+    az: t("fields.availabilityZone"),
   };
   return {
     fields,


### PR DESCRIPTION
The instance can give us a boolean value `multi_az` from which we can compute if the instance is of type 'single' or 'multi'