### PR TITLE
fix: proper link to the overview page

### DIFF
--- a/apps/consoledot-rhosak/src/routes/control-plane/routes/CreateKafkaInstanceRoute.tsx
+++ b/apps/consoledot-rhosak/src/routes/control-plane/routes/CreateKafkaInstanceRoute.tsx
@@ -22,7 +22,7 @@ export const CreateKafkaInstanceRoute: FunctionComponent<
 
   const onClickKafkaOverview = () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
-    history.push(`overview`);
+    history.push(`/overview`);
   };
 
   const onClickQuickStart = useCallback(() => {


### PR DESCRIPTION
This fixes the links in the create Kafka dialog.