### PR TITLE
chore: fix create service account button

### DIFF
--- a/apps/consoledot-rhosak/fec.config.js
+++ b/apps/consoledot-rhosak/fec.config.js
@@ -18,7 +18,7 @@ module.exports = {
     }),
   ],
   _unstableHotReload: process.env.HOT === "true",
-  sassPrefix: ".rhosakUi",
+  sassPrefix: ".rhosak",
   // localChrome:
   //   "/Users/riccardoforina/Code/bf2fc6cc711aee1a0c2a/insights-chrome/build",
   routes: {

--- a/packages/ui/src/components/KafkaInstanceDrawer/components/KafkaConnectionTabP2.tsx
+++ b/packages/ui/src/components/KafkaInstanceDrawer/components/KafkaConnectionTabP2.tsx
@@ -105,8 +105,11 @@ export const KafkaConnectionTabP2: FunctionComponent<
       <Button
         variant={ButtonVariant.secondary}
         isInline
-        onClick={showCreateServiceAccountModal}
         data-testid="drawerStreams-buttonCreateServiceAccount"
+        href={`${
+          document.location.pathname.startsWith("/beta") ? "/beta" : ""
+        }/application-services/service-account`}
+        component={"a"}
       >
         {t("connection-tab:create_service_account")}
       </Button>

--- a/packages/ui/src/components/KafkaInstanceDrawer/components/__snapshots__/kafkaConnectionTabP2.test.tsx.snap
+++ b/packages/ui/src/components/KafkaInstanceDrawer/components/__snapshots__/kafkaConnectionTabP2.test.tsx.snap
@@ -114,17 +114,17 @@ exports[`ConnectionTab renders 1`] = `
            page.
         </small>
       </div>
-      <button
+      <a
         aria-disabled="false"
         class="pf-c-button pf-m-secondary"
         data-ouia-component-id="OUIA-Generated-Button-secondary-1"
         data-ouia-component-type="PF4/Button"
         data-ouia-safe="true"
         data-testid="drawerStreams-buttonCreateServiceAccount"
-        type="button"
+        href="/application-services/service-account"
       >
         Create service account
-      </button>
+      </a>
       <div
         class="pf-c-content pf-u-pt-sm"
       >

--- a/packages/ui/src/components/KafkaInstanceDrawer/components/kafkaConnectionTabP2.test.tsx
+++ b/packages/ui/src/components/KafkaInstanceDrawer/components/kafkaConnectionTabP2.test.tsx
@@ -35,9 +35,7 @@ describe("ConnectionTab", () => {
       "https://api.openshift.com/api/kafkas_mgmt/v1/openapi"
     );
 
-    expect(
-      comp.getByRole("button", { name: "Create service account" })
-    ).toHaveAttribute(
+    expect(comp.getByText("Create service account")).toHaveAttribute(
       "data-testid",
       "drawerStreams-buttonCreateServiceAccount"
     );


### PR DESCRIPTION
link to the service account page from the connection tab when clicking on the create service account button

