### PR TITLE
chore: Fix permissions table not showing more than ten values

### DIFF
--- a/packages/consoledot-api/src/queries/useAcls.ts
+++ b/packages/consoledot-api/src/queries/useAcls.ts
@@ -28,6 +28,7 @@ export function useAcls(
 
       return fetchPermissions({
         getAcls: (...args) => api.getAcls(...args),
+        ...params,
       });
     },
     enabled: Boolean(params.adminUrl),


### PR DESCRIPTION
- Per page value was being received as undefined because of which entries over ten were not being shown on the table 