### PR TITLE
chore: Bug fixes

### DIFF
--- a/apps/consoledot-rhosak/src/routes/control-plane/routes/ChangeOwnerRoute.tsx
+++ b/apps/consoledot-rhosak/src/routes/control-plane/routes/ChangeOwnerRoute.tsx
@@ -48,14 +48,7 @@ export const ChangeOwnerRoute: FunctionComponent<
         }
       );
     },
-    [
-      addAlert,
-      history,
-      instance.id,
-      instance.name,
-      instancesHref,
-      updateInstance,
-    ]
+    [addAlert, history, instance.id, instance.name, updateInstance]
   );
 
   const savingState = ((): ChangeKafkaOwnerProps["savingState"] => {

--- a/apps/consoledot-rhosak/src/routes/control-plane/routes/ChangeOwnerRoute.tsx
+++ b/apps/consoledot-rhosak/src/routes/control-plane/routes/ChangeOwnerRoute.tsx
@@ -23,8 +23,8 @@ export const ChangeOwnerRoute: FunctionComponent<
 
   const onCancel = useCallback(() => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
-    history.push(instancesHref);
-  }, [history, instancesHref]);
+    history.goBack();
+  }, [history]);
 
   const onConfirm = useCallback(
     (newOwner: string) => {
@@ -36,7 +36,7 @@ export const ChangeOwnerRoute: FunctionComponent<
         {
           onSuccess: () => {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
-            history.replace(instancesHref);
+            history.goBack();
             addAlert(
               "success",
               "Kafka instance owner changed",

--- a/apps/consoledot-rhosak/src/routes/data-plane/routes/TopicDeleteRoute.tsx
+++ b/apps/consoledot-rhosak/src/routes/data-plane/routes/TopicDeleteRoute.tsx
@@ -20,8 +20,8 @@ export const TopicDeleteRoute: VoidFunctionComponent<
 
   const onCancel = useCallback(() => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
-    history.push(instanceTopicsHref(instance.id));
-  }, [history, instance.id, instanceTopicsHref]);
+    history.goback();
+  }, [history]);
 
   const onDelete = useCallback(() => {
     if (!instance.adminUrl) {


### PR DESCRIPTION
**What this PR does / why we need it**:

- [x] If the "onCancel" button is clicked in the "DeleteTopic" component from the "Topic Properties" page, it should redirect back to the "Topic Properties" page.
- [x] If the "onCancel" button is clicked in the "DeleteTopic" component from the "Topic Table" page, it should redirect back to the "Topic Table" page.

**Which issue(s) this PR fixes** 

**Change owner route**
 When you change the owner from Instance detail screen, on changing the owner the page routes to Kafka Instances list.

**Delete topic route**
 If you click on Delete Topic, and then click Cancel, instead of routing to the Topic list screen, the Topic Detail screen gets opened. The expectation is if Delete is opened from the Topic properties screen and cancel is pressed, the topic properties screen should open, but if Delete is clicked from the kebab in Topic list screen, then it should open the Topic list screen instead.

**Verification steps** 

> Attach a screenshot of the output.
> guidance on how to go the particular story.
> e.g. `point to the story with a text breadcrumb, something like "components > <component name> > <story name>”`

**Is there any work left / what's next** :

> Replace this comment with pending items that need to be covered in this PR or some pending items you are planning to do in the future PR.

**Special notes for your reviewer**:
