### PR TITLE
chore: catch api error while fetching user accounts

### DIFF
--- a/packages/consoledot-api/src/fetchers/fetchUserAccounts.ts
+++ b/packages/consoledot-api/src/fetchers/fetchUserAccounts.ts
@@ -11,7 +11,7 @@ export type FetchUserAccountsParams = {
 export async function fetchUserAccounts({
   getUserAccounts,
 }: FetchUserAccountsParams): Promise<{
-  accounts: UserAccount[] | [];
+  accounts: UserAccount[];
   count: number;
 }> {
   try {

--- a/packages/consoledot-api/src/fetchers/fetchUserAccounts.ts
+++ b/packages/consoledot-api/src/fetchers/fetchUserAccounts.ts
@@ -11,21 +11,25 @@ export type FetchUserAccountsParams = {
 export async function fetchUserAccounts({
   getUserAccounts,
 }: FetchUserAccountsParams): Promise<{
-  accounts: UserAccount[];
+  accounts: UserAccount[] | [];
   count: number;
 }> {
-  const response = await getUserAccounts(-1);
-  const accounts = response.data.data.map<UserAccount>((p) => {
-    const fullObject = p as Principal;
-    return {
-      username: fullObject.username,
-      displayName: `${fullObject.first_name || ""} ${
-        fullObject.last_name || ""
-      }`.trim(),
-      email: fullObject.email,
-      isOrgAdmin: fullObject.is_org_admin || false,
-    };
-  });
-  const count = accounts.length;
-  return { count, accounts };
+  try {
+    const response = await getUserAccounts(-1);
+    const accounts = response.data.data.map<UserAccount>((p) => {
+      const fullObject = p as Principal;
+      return {
+        username: fullObject.username,
+        displayName: `${fullObject.first_name || ""} ${
+          fullObject.last_name || ""
+        }`.trim(),
+        email: fullObject.email,
+        isOrgAdmin: fullObject.is_org_admin || false,
+      };
+    });
+    const count = accounts.length;
+    return { count, accounts };
+  } catch {
+    return { accounts: [], count: 0 };
+  }
 }


### PR DESCRIPTION
If the user account api fails which it can for non admin users, we handle it by sending an empty list of accounts