### PR TITLE
chore: Provide correct warning message when editing partitions

### DIFF
--- a/packages/locales/en/create-topic.json
+++ b/packages/locales/en/create-topic.json
@@ -72,6 +72,8 @@
   "min_insync_replicas_description": "Minimum in-sync replicas is the minimum number of replicas that must acknowledge a write for the write to be considered successful. This property assumes that the producer requests acknowledgements from all replicas (`acks` set to `all`). If this minimum is not met, the producer raises an exception (`NotEnoughReplicas` or `NotEnoughReplicasAfterAppend`). Typically you create a topic with a replication factor of 3, set `min.insync.replicas` to 2, and set the producer `acks` to `all`.(min.insync.replicas)",
   "no_return": "No, return to form",
   "partition_helper_text": "One partition is sufficient for getting started, but production systems often have more.",
+  "partition_increase": "Messages might have the same key from two different partitions, which can potentially break the message ordering guarantees that apply to a single partition.",
+  "partition_increase_helper_text": "Increasing a topic's partitions might result in messages having the same key from two different partitions, which can potentially break the message ordering guarantees that apply to a single partition",
   "partition_info": "An ordered list of messages",
   "partition_info_note": "One or more partitions make up a topic. Partitions are distributed across the brokers to increase the scalability of your topic. You can also use them to distribute messages across the members of the consumer group.",
   "partition_warning_modal": "Since this Kafka Instance has already reached its maximum partition limit, increasing the number of partitions might result in degraded performance.",

--- a/packages/ui/src/components/Topic/EditTopicProperties/EditTopicProperties.tsx
+++ b/packages/ui/src/components/Topic/EditTopicProperties/EditTopicProperties.tsx
@@ -126,6 +126,7 @@ export const EditTopicProperties: FunctionComponent<
           onSave={onTransform}
           isModalOpen={warningModalOpen}
           setIsModalOpen={setWarningModalOpen}
+          isCreate={false}
         />
       )}
     </PageSection>

--- a/packages/ui/src/components/Topic/components/CoreConfiguration.tsx
+++ b/packages/ui/src/components/Topic/components/CoreConfiguration.tsx
@@ -139,6 +139,17 @@ const CoreConfiguration: FunctionComponent<CoreConfigurationProps> = ({
     />
   );
 
+  const partitionsHelperText =
+    isCreate && partitions >= availablePartitionLimit
+      ? t("partitions_warning")
+      : !isCreate && partitions > initialPartitions
+      ? t("partition_increase_helper_text")
+      : t("partition_helper_text");
+  const partitionsValidated =
+    (isCreate && partitions >= availablePartitionLimit) ||
+    (!isCreate && partitions > initialPartitions)
+      ? "warning"
+      : "default";
   return (
     <FormSection
       title={t("core_configuration")}
@@ -191,16 +202,8 @@ const CoreConfiguration: FunctionComponent<CoreConfigurationProps> = ({
         labelHead={t("partitions")}
         labelBody={t("partitions_description")}
         buttonAriaLabel="More info for partitions field"
-        helperText={
-          topicData.partitions.length >= availablePartitionLimit
-            ? t("partitions_warning")
-            : t("partition_helper_text")
-        }
-        validated={
-          topicData.partitions.length >= availablePartitionLimit
-            ? "warning"
-            : "default"
-        }
+        helperText={partitionsHelperText}
+        validated={partitionsValidated}
       >
         <NumberInput
           id="create-topic-partitions"

--- a/packages/ui/src/components/Topic/components/CreateTopicWizard.tsx
+++ b/packages/ui/src/components/Topic/components/CreateTopicWizard.tsx
@@ -222,6 +222,7 @@ export const CreateTopicWizard: React.FC<CreateTopicWizardProps> = ({
                 onSave={onTransform}
                 isModalOpen={warningModalOpen}
                 setIsModalOpen={setWarningModalOpen}
+                isCreate={true}
               />
             )}
           </PageSection>
@@ -255,6 +256,7 @@ export const CreateTopicWizard: React.FC<CreateTopicWizardProps> = ({
               onSave={onTransform}
               isModalOpen={warningModalOpen}
               setIsModalOpen={setWarningModalOpen}
+              isCreate={true}
             />
           )}
         </PageSection>

--- a/packages/ui/src/components/Topic/components/PartitionLimitWarning.tsx
+++ b/packages/ui/src/components/Topic/components/PartitionLimitWarning.tsx
@@ -7,6 +7,7 @@ export type PartitionLimitWarningProps = {
   onSave: (topicData: Topic) => void;
   isModalOpen: boolean;
   setIsModalOpen: (value: boolean) => void;
+  isCreate: boolean;
 };
 
 export const PartitionLimitWarning: React.FC<PartitionLimitWarningProps> = ({
@@ -14,6 +15,7 @@ export const PartitionLimitWarning: React.FC<PartitionLimitWarningProps> = ({
   onSave,
   isModalOpen,
   setIsModalOpen,
+  isCreate,
 }) => {
   const { t } = useTranslation(["create-topic"]);
 
@@ -41,7 +43,7 @@ export const PartitionLimitWarning: React.FC<PartitionLimitWarningProps> = ({
         </Button>,
       ]}
     >
-      {t("partition_warning_modal")}
+      {isCreate ? t("partition_warning_modal") : t("partition_increase")}
     </Modal>
   );
 };

--- a/packages/ui/src/components/Topic/components/PartitionsLimitWarning.stories.tsx
+++ b/packages/ui/src/components/Topic/components/PartitionsLimitWarning.stories.tsx
@@ -13,12 +13,22 @@ const Template: ComponentStory<typeof PartitionLimitWarning> = (args) => (
   <PartitionLimitWarning {...args} />
 );
 
-export const EmptyState = Template.bind({});
-EmptyState.args = {};
-EmptyState.parameters = {
+export const CreateTopicWarning = Template.bind({});
+CreateTopicWarning.args = { isCreate: true };
+CreateTopicWarning.parameters = {
   docs: {
     description: {
-      story: `A modal when creating a toic that has reached or exceeded available number of partitions`,
+      story: `A modal when creating a topic that has reached or exceeded available number of partitions`,
+    },
+  },
+};
+
+export const EditTopicWarning = Template.bind({});
+EditTopicWarning.args = { isCreate: false };
+EditTopicWarning.parameters = {
+  docs: {
+    description: {
+      story: `A modal when editing a topic that shows up when user increases the number of partitions`,
     },
   },
 };

--- a/packages/ui/src/components/Topic/components/PartitionsLimitWarning.test.tsx
+++ b/packages/ui/src/components/Topic/components/PartitionsLimitWarning.test.tsx
@@ -3,14 +3,14 @@ import { composeStories } from "@storybook/testing-react";
 import { render, waitForI18n } from "../../../test-utils";
 import * as stories from "./PartitionsLimitWarning.stories";
 
-const { EmptyState } = composeStories(stories);
+const { EditTopicWarning, CreateTopicWarning } = composeStories(stories);
 
 describe("Partitions warning", () => {
   it("should render a partitions warning modal", async () => {
     const onSave = jest.fn();
     const isModalOpen = jest.fn();
     const comp = render(
-      <EmptyState onSave={onSave} setIsModalOpen={isModalOpen} />
+      <CreateTopicWarning onSave={onSave} setIsModalOpen={isModalOpen} />
     );
     await waitForI18n(comp);
     expect(
@@ -19,6 +19,28 @@ describe("Partitions warning", () => {
     expect(
       comp.getByText(
         "Since this Kafka Instance has already reached its maximum partition limit, increasing the number of partitions might result in degraded performance."
+      )
+    ).toBeInTheDocument();
+    expect(comp.getByText("No, return to form")).toBeInTheDocument();
+    expect(comp.getByText("Yes")).toBeInTheDocument();
+    userEvent.click(comp.getByText("No, return to form"));
+    expect(isModalOpen).toBeCalledTimes(1);
+    userEvent.click(comp.getByText("Yes"));
+    expect(onSave).toBeCalledTimes(1);
+  });
+  it("should render a partitions warning modal when editing a topic", async () => {
+    const onSave = jest.fn();
+    const isModalOpen = jest.fn();
+    const comp = render(
+      <EditTopicWarning onSave={onSave} setIsModalOpen={isModalOpen} />
+    );
+    await waitForI18n(comp);
+    expect(
+      comp.getByText("Increase the number of partitions?")
+    ).toBeInTheDocument();
+    expect(
+      comp.getByText(
+        "Messages might have the same key from two different partitions, which can potentially break the message ordering guarantees that apply to a single partition."
       )
     ).toBeInTheDocument();
     expect(comp.getByText("No, return to form")).toBeInTheDocument();


### PR DESCRIPTION
- We were earlier seeing the same warning when creating or editing a topic with increased partitions. In case we are editing a topic and increasing the partitions,  a warning message should show up regardless of what value of partitions we have while in creating a topic, a warning should show up only when we have reached the partitions limit. 