### PR TITLE
fix: load the MAS federated modules from app-services-ui

### DIFF
--- a/apps/consoledot-rhosak/fec.config.js
+++ b/apps/consoledot-rhosak/fec.config.js
@@ -34,13 +34,6 @@ module.exports = {
   },
   moduleFederation: {
     exclude: ["react-router-dom"],
-    shared: [
-      {
-        "react-i18next": {
-          singleton: true,
-          requiredVersion: "*",
-        },
-      },
-    ],
+    shared: [],
   },
 };

--- a/apps/consoledot-rhosak/fec.config.js
+++ b/apps/consoledot-rhosak/fec.config.js
@@ -22,6 +22,9 @@ module.exports = {
   // localChrome:
   //   "/Users/riccardoforina/Code/bf2fc6cc711aee1a0c2a/insights-chrome/build",
   routes: {
+    "/apps/application-services": {
+      host: "https://localhost:2222",
+    },
     "/config": {
       host: "http://localhost:8889",
     },
@@ -33,14 +36,6 @@ module.exports = {
     exclude: ["react-router-dom"],
     shared: [
       {
-        "react-router-dom": {
-          singleton: false,
-          requiredVersion: "5.3.4",
-        },
-        "@rhoas/app-services-ui-shared": {
-          singleton: true,
-          requiredVersion: "*",
-        },
         "react-i18next": {
           singleton: true,
           requiredVersion: "*",

--- a/apps/consoledot-rhosak/fec.config.js
+++ b/apps/consoledot-rhosak/fec.config.js
@@ -22,15 +22,15 @@ module.exports = {
   // localChrome:
   //   "/Users/riccardoforina/Code/bf2fc6cc711aee1a0c2a/insights-chrome/build",
   routes: {
-    "/apps/application-services": {
-      host: "https://localhost:2222",
-    },
-    "/config": {
-      host: "http://localhost:8889",
-    },
-    "/beta/config": {
-      host: "http://localhost:8889",
-    },
+    // "/apps/application-services": {
+    //   host: "https://localhost:2222",
+    // },
+    // "/config": {
+    //   host: "http://localhost:8889",
+    // },
+    // "/beta/config": {
+    //   host: "http://localhost:8889",
+    // },
   },
   moduleFederation: {
     exclude: ["react-router-dom"],

--- a/apps/consoledot-rhosak/package.json
+++ b/apps/consoledot-rhosak/package.json
@@ -30,7 +30,6 @@
     "@redhat-cloud-services/rbac-client": "1.2.0",
     "@rhoas/account-management-sdk": "0.51.0",
     "@rhoas/app-services-ui-components": "2.20.5",
-    "@rhoas/app-services-ui-shared": "0.16.6",
     "@rhoas/kafka-instance-sdk": "0.51.0",
     "@rhoas/kafka-management-sdk": "0.51.0",
     "@rhoas/registry-management-sdk": "0.51.0",

--- a/apps/consoledot-rhosak/src/QuickstartLoader.tsx
+++ b/apps/consoledot-rhosak/src/QuickstartLoader.tsx
@@ -1,10 +1,8 @@
 /* eslint-disable */
 // @ts-nocheck
-import { useChrome } from "@redhat-cloud-services/frontend-components/useChrome";
-import { AssetsContext } from "@rhoas/app-services-ui-shared";
 import { ScalprumComponent } from "@scalprum/react-core";
 import type { VoidFunctionComponent } from "react";
-import { Suspense, useState } from "react";
+import { Suspense } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 
 export const appIdentifier = "applicationServices";
@@ -15,39 +13,15 @@ const getPath = () => {
 };
 
 export const QuickstartLoader: VoidFunctionComponent = () => {
-  const [loaded, setLoaded] = useState(false);
-  const chrome = useChrome();
-  const { quickStarts } = chrome;
-
-  const onLoad = (qs: unknown) => {
-    if (quickStarts) {
-      setLoaded(true); // unload federated module
-      quickStarts.set(appIdentifier, qs);
-    }
-  };
-
-  const processor = (item) => {
-    const fixPath = (e) => `${basePath}${e}`;
-    return item.guides.entry.map(fixPath);
-  };
-
   return (
     <Suspense fallback={null}>
       <ErrorBoundary fallbackRender={() => null}>
-        <AssetsContext.Provider value={{ getPath }}>
-          {!loaded ? (
-            <ScalprumComponent
-              appName="guides"
-              scope="guides"
-              module="./QuickStartLoader"
-              ErrorComponent={null}
-              processor={processor}
-              showDrafts={false}
-              onLoad={onLoad}
-              fallback={() => null}
-            />
-          ) : null}
-        </AssetsContext.Provider>
+        <ScalprumComponent
+          appName="applicationServices"
+          scope="applicationServices"
+          module="./Guides"
+          ErrorComponent={null}
+        />
       </ErrorBoundary>
     </Suspense>
   );

--- a/apps/consoledot-rhosak/src/routes/data-plane/routes/TopicSchemasRoute.tsx
+++ b/apps/consoledot-rhosak/src/routes/data-plane/routes/TopicSchemasRoute.tsx
@@ -1,12 +1,6 @@
 /* eslint-disable */
 // @ts-nocheck
-import { useChrome } from "@redhat-cloud-services/frontend-components/useChrome";
-import { I18nProvider } from "@rhoas/app-services-ui-components";
-import type { Auth, Config } from "@rhoas/app-services-ui-shared";
-import { AuthContext, ConfigContext } from "@rhoas/app-services-ui-shared";
 /* tslint:disable */
-import type { Registry } from "@rhoas/registry-management-sdk";
-import type { ScalprumComponentProps } from "@scalprum/react-core";
 import { ScalprumComponent } from "@scalprum/react-core";
 import type { VoidFunctionComponent } from "react";
 import type { DataPlaneNavigationProps } from "../routesConsts";
@@ -16,23 +10,7 @@ import { DataPlaneTopicHeaderConnected } from "./DataPlaneTopicHeaderConnected";
 export const TopicSchemasRoute: VoidFunctionComponent<
   DataPlaneNavigationProps
 > = ({ instanceDetailsHref, instanceTopicsHref, instancesHref }) => {
-  const chrome = useChrome();
   const { topic } = useTopicGate();
-  const processor = (([_, m]: [string, { entry: string[] }]) =>
-    m.entry.map(
-      (e) => `/beta/apps/srs-ui-build${e}`
-    )) as unknown as ScalprumComponentProps["processor"];
-  const processor2 = (([_, m]: [string, { entry: string[] }]) =>
-    m.entry.map(
-      (e) => `/beta/apps/sr-ui-build${e}`
-    )) as unknown as ScalprumComponentProps["processor"];
-  const basename = "/service-registry";
-  const auth: Auth = {
-    srs: { getToken: chrome.auth.getToken },
-  };
-  const config: Config = {
-    srs: { apiBasePath: process.env.API_URL },
-  };
   return (
     <>
       <DataPlaneTopicHeaderConnected
@@ -41,54 +19,12 @@ export const TopicSchemasRoute: VoidFunctionComponent<
         instanceTopicsHref={instanceTopicsHref}
         activeSection={"schemas"}
       />
-      <AuthContext.Provider value={auth}>
-        <ConfigContext.Provider value={config}>
-          <I18nProvider
-            lng={"en"}
-            resources={{
-              en: {
-                common: () =>
-                  import(
-                    "@rhoas/app-services-ui-components/locales/en/common.json"
-                  ),
-                "service-registry": () =>
-                  import(
-                    "@rhoas/app-services-ui-components/locales/en/service-registry.json"
-                  ),
-                srsTemporaryFixMe: () => import("./srs-locales.json"),
-              },
-            }}
-            debug={true}
-          >
-            <ScalprumComponent
-              appName="srs"
-              module="./ServiceRegistryMapping"
-              scope="srs"
-              ErrorComponent={<div>opsie</div>}
-              processor={processor}
-              basename={basename}
-              topicName={topic.name}
-              renderSchema={(registry: Registry) => {
-                return (
-                  <ScalprumComponent
-                    appName="ar"
-                    scope="ar"
-                    ErrorComponent={<div>opsie</div>}
-                    processor={processor2}
-                    module="./FederatedSchemaMapping"
-                    registry={registry}
-                    topicName={topic.name}
-                    groupId={null}
-                    version={"latest"}
-                    registryId={registry?.id}
-                    basename={basename}
-                  />
-                );
-              }}
-            />
-          </I18nProvider>
-        </ConfigContext.Provider>
-      </AuthContext.Provider>
+      <ScalprumComponent
+        appName="applicationServices"
+        scope="applicationServices"
+        module="./TopicSchema"
+        topicName={topic.name}
+      />
     </>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "@redhat-cloud-services/rbac-client": "1.2.0",
         "@rhoas/account-management-sdk": "0.51.0",
         "@rhoas/app-services-ui-components": "2.20.5",
-        "@rhoas/app-services-ui-shared": "0.16.6",
         "@rhoas/kafka-instance-sdk": "0.51.0",
         "@rhoas/kafka-management-sdk": "0.51.0",
         "@rhoas/registry-management-sdk": "0.51.0",
@@ -247,6 +246,7 @@
       "version": "0.16.6",
       "resolved": "https://registry.npmjs.org/@rhoas/app-services-ui-shared/-/app-services-ui-shared-0.16.6.tgz",
       "integrity": "sha512-/3AF9Ovdk1HP0CuhlqtaUECkRuNwmqA0iw/joPiZCBixJ49Whe11Uc+UnZfBjxjkUxvF6WKxJrJPG5iPdL2TBQ==",
+      "peer": true,
       "dependencies": {
         "tslib": "2.4.1"
       },


### PR DESCRIPTION
This loads the Quickstarts and the Topic Schema components from app-services-ui, without the need to know how they work.

This is to be considered temporary, as ideally:
* the quickstarts should embrace consoledot's way of loading the content, removing the need of a custom component (cc @bredamc, doc here https://github.com/RedHatInsights/quickstarts/blob/main/docs/quickstarts/README.md)
* service registry should become a consoledot native app, with a fed module exposed for us to load the widget we need without having to pass through app-services-ui (cc @EricWittmann)

This depends on https://github.com/redhat-developer/app-services-ui/pull/823