### PR TITLE
chore: show skeleton when bootstrap url is undefined in the sample code snippet

### DIFF
--- a/packages/ui/src/components/KafkaInstanceDrawer/KafkaInstanceDrawer.tsx
+++ b/packages/ui/src/components/KafkaInstanceDrawer/KafkaInstanceDrawer.tsx
@@ -185,7 +185,7 @@ export const KafkaInstanceDrawerPanel: VoidFunctionComponent<
           >
             <div className={"pf-u-pt-md pf-u-pb-md"}>
               <KafkaSampleCode
-                kafkaBootstrapUrl={getExternalServer(instance.bootstrapUrl)!}
+                kafkaBootstrapUrl={getExternalServer(instance.bootstrapUrl)}
                 tokenEndpointUrl={tokenEndpointUrl}
               />
             </div>

--- a/packages/ui/src/components/KafkaInstanceDrawer/components/KafkaSampleCode.tsx
+++ b/packages/ui/src/components/KafkaInstanceDrawer/components/KafkaSampleCode.tsx
@@ -43,7 +43,7 @@ import {
 export type ClientType = "java" | "python" | "quarkus" | "springboot";
 
 export type KafkaSampleCodeProps = {
-  kafkaBootstrapUrl: string;
+  kafkaBootstrapUrl: string | undefined;
   tokenEndpointUrl: string | undefined;
 };
 
@@ -113,7 +113,7 @@ export const KafkaSampleCode: VoidFunctionComponent<KafkaSampleCodeProps> = ({
         {(() => {
           switch (clientSelect) {
             case "java":
-              return tokenEndpointUrl ? (
+              return kafkaBootstrapUrl && tokenEndpointUrl ? (
                 <SampleCodeSnippet
                   codeBlockCode={javaConfigCodeBlock(
                     kafkaBootstrapUrl,
@@ -126,7 +126,7 @@ export const KafkaSampleCode: VoidFunctionComponent<KafkaSampleCodeProps> = ({
                 <Skeleton fontSize="4xl" />
               );
             case "python":
-              return tokenEndpointUrl ? (
+              return kafkaBootstrapUrl && tokenEndpointUrl ? (
                 <SampleCodeSnippet
                   codeBlockCode={pythonConfigCodeBlock(tokenEndpointUrl)}
                   expandableCode={pythonConfigExpandabledBlock(
@@ -138,7 +138,7 @@ export const KafkaSampleCode: VoidFunctionComponent<KafkaSampleCodeProps> = ({
                 <Skeleton fontSize="4xl" />
               );
             case "quarkus":
-              return tokenEndpointUrl ? (
+              return kafkaBootstrapUrl && tokenEndpointUrl ? (
                 <SampleCodeSnippet
                   codeBlockCode={quarkusConfigCodeBlock}
                   expandableCode={quarkusConfigExpandableBlock(
@@ -151,7 +151,7 @@ export const KafkaSampleCode: VoidFunctionComponent<KafkaSampleCodeProps> = ({
                 <Skeleton fontSize="4xl" />
               );
             case "springboot":
-              return tokenEndpointUrl ? (
+              return kafkaBootstrapUrl && tokenEndpointUrl ? (
                 <SampleCodeSnippet
                   codeBlockCode={springBootConfigCodeBlock(
                     kafkaBootstrapUrl,


### PR DESCRIPTION
**What this PR does / why we need it**:

> show skeleton when bootstrap URL is undefined in the sample code snippet 

**Which issue(s) this PR fixes** 

> Replace this comment with references to related issues.
> e.g. `fixes #<issue number>`

**Verification steps** 

> Attach a screenshot of the output.
> guidance on how to go the particular story.
> e.g. `point to the story with a text breadcrumb, something like "components > <component name> > <story name>”`

**Is there any work left / what's next** :

> Replace this comment with pending items that need to be covered in this PR or some pending items you are planning to do in the future PR.

**Special notes for your reviewer**:
