### PR TITLE
chore: Add ouiaid to permissions toolbar and kebab

### DIFF
--- a/packages/ui/src/components/ManageKafkaPermissions/components/PermissionsTable.tsx
+++ b/packages/ui/src/components/ManageKafkaPermissions/components/PermissionsTable.tsx
@@ -88,6 +88,8 @@ export const PermissionsTable = <T extends Permissions>({
         variant={TableVariant.compact}
         tableOuiaId={"permissions-table"}
         ariaLabel={t("consumerGroup.consumer_group_list")}
+        toolbarKebabOuiaId={"permissions-tolbar-kebab"}
+        toolbarOuiaId={"permissions-toolbar"}
         actions={[
           {
             onClick: onManagePermissions,

--- a/packages/ui/src/components/ManageKafkaPermissions/components/ResourceName.tsx
+++ b/packages/ui/src/components/ManageKafkaPermissions/components/ResourceName.tsx
@@ -91,6 +91,7 @@ export const ResourceName: React.VFC<ResourceNameProps> = ({
       isInputFilterPersisted={true}
       isInputValuePersisted={true}
       width={220}
+      createText={t("resourcePrefix.create_text")}
     />
   );
 };


### PR DESCRIPTION
Add ouiaId for permissions table 
Change the resource name `createText` prop from create to use